### PR TITLE
[Feature] Add transport client for SSE-based MCP servers

### DIFF
--- a/JS/sse.js
+++ b/JS/sse.js
@@ -1,0 +1,191 @@
+/**
+ * Test SSE-based MCP server for the unit tests in the package.
+ *   - Serves a Server-Sent Events (SSE) endpoint at `/sse`
+ *   - Sends an "endpoint" event to the SSE client upon connection, containing a POST URL for subsequent messages
+ *   - Receives POST data at the returned URL (hosted over localhost), example path: `/message?sessionId=...`. Data is echo'd automatically
+ *   - Logs connect/disconnect/error events to the console
+ *   - Test messages:
+ *       - "client::disconnect" -> the downchannel is disconnected
+ *       - "client::badMessage" -> malformed payload is sent on the downchannel
+ *       - "client::changeEndpoint" -> endpoint will be updated (with a new sessionId)
+ *
+ * Usage:
+ *   1. Run `node sse.js`
+ *   2. Your SSE client (Swift, or other) connects to `http://127.0.0.1:3000/sse`
+ *   3. The server sends an "endpoint" event telling the client how to POST messages
+ *   4. You can send messages to the server by making a POST request to `/message?sessionId=XXX`
+ */
+
+const http = require("http");
+const { randomUUID } = require("crypto");
+
+/**
+ * @typedef {Object} SSEClient
+ * @property {string} sessionId - Unique session identifier
+ * @property {string} host - The host of the POST url for this client
+ * @property {http.ServerResponse} response - The Node.js response that we write SSE data into
+ */
+
+/** @type {Map<string, SSEClient>} */
+const sseClients = new Map();
+
+/**
+ * Creates an HTTP server listening on port 3000.
+ * - GET /sse: opens an SSE stream, sets up an endpoint event
+ * - POST /message?sessionId=... : sends data to a specific SSE client
+ */
+const server = http.createServer((req, res) => {
+    const url = new URL(req.url, `http://${req.headers.host}`);
+    const { pathname, searchParams } = url;
+
+    // SSE Endpoint
+    if (req.method === "GET" && pathname === "/sse") {
+        handleSSEConnection(req, res);
+        return;
+    }
+
+    // Incoming message for SSE client
+    if (req.method === "POST" && pathname === "/message") {
+        handlePostMessage(req, res, searchParams);
+        return;
+    }
+
+    // Otherwise, 404
+    res.writeHead(404, { "Content-Type": "text/plain" });
+    res.end("Not found\n");
+});
+
+/**
+ * Returns the endpoint URL for the given SSE client.
+ * @param {SSEClient} sseClient - The SSE client, where the endpoint URL is derived from
+ */
+function sendEndpointEvent(sseClient) {
+    sendSSEEvent(sseClient.response, "endpoint", `http://${sseClient.host}/message?sessionId=${sseClient.sessionId}`);
+}
+
+/**
+ * Handles a new SSE connection on /sse.
+ *
+ * @param {http.IncomingMessage} req - The HTTP request
+ * @param {http.ServerResponse} res - The HTTP response (to be used as SSE stream)
+ */
+function handleSSEConnection(req, res) {
+    const sessionId = randomUUID();
+
+    // pre-headers
+    res.writeHead(200, {
+        "Content-Type": "text/event-stream",
+        "Cache-Control": "no-cache",
+        Connection: "keep-alive",
+    });
+
+    /** @type {SSEClient} */
+    const sseClient = {
+        host: req.headers.host,
+        sessionId,
+        response: res,
+    };
+    sseClients.set(sessionId, sseClient);
+
+    console.log(`[SSE] Client connected: sessionId = ${sessionId}`);
+
+    // Send the endpoint URL to the client
+    sendEndpointEvent(sseClient);
+
+    // listen for disconnect
+    req.on("close", () => {
+        console.log(`[SSE] Client disconnected: sessionId = ${sessionId}`);
+        sseClients.delete(sessionId);
+    });
+
+    // simulate keep-alive / activity
+    setInterval(() => {
+        sendSSEEvent(res, "message", JSON.stringify({ time: Date.now() }));
+    }, 5000);
+}
+
+/**
+ * Handles a POST request to /message?sessionId=...
+ * Reads the entire request body as text, then sends it as "message" event to the matching SSE client.
+ *
+ * @param {http.IncomingMessage} req - The HTTP request
+ * @param {http.ServerResponse} res - The HTTP response
+ * @param {URLSearchParams} searchParams - Query parameters
+ */
+function handlePostMessage(req, res, searchParams) {
+    const sessionId = searchParams.get("sessionId");
+    if (!sessionId) {
+        res.writeHead(400, { "Content-Type": "text/plain" });
+        return res.end("Missing sessionId\n");
+    }
+
+    const sseClient = sseClients.get(sessionId);
+    if (!sseClient) {
+        res.writeHead(404, { "Content-Type": "text/plain" });
+        return res.end("No SSE client with that sessionId\n");
+    }
+
+    let bodyData = "";
+    req.on("data", (chunk) => {
+        bodyData += chunk;
+    });
+
+    req.on("end", () => {
+        // we have the full response
+        console.log(`[SSE] Received POST for sessionId=${sessionId}, data="${bodyData}"`);
+        const ack = () => {
+            res.writeHead(202, { "Content-Type": "text/plain" });
+            res.end("ack\n");
+        };
+
+        // test messages
+        if (bodyData.includes("client::disconnect")) {
+            console.log(`[SSE] Disconnecting sessionId=${sessionId}`);
+            sseClient.response.end();
+            sseClients.delete(sessionId);
+            return;
+        } else if (bodyData.includes("client::badMessage")) {
+            console.log(`[SSE] Sending bad message to sessionId=${sessionId}`);
+            res.writeHead(500, { "Content-Type": "text/plain" });
+            res.end("ERROR: NOT OK");
+            return;
+        } else if (bodyData.includes("client::changeEndpoint")) {
+            console.log(`[SSE] Changing endpoint for sessionId=${sessionId}`);
+            // update sessionId to change the endpoint
+            sseClient.sessionId = randomUUID();
+            sendEndpointEvent(sseClient);
+            ack();
+            return;
+        }
+        ack();
+    });
+
+    req.on("error", (err) => {
+        console.error(`[SSE] Error reading POST data: ${err}`);
+    });
+}
+
+/**
+ * Sends an SSE event to the given response.
+ *
+ * @param {http.ServerResponse} res - The response to write to
+ * @param {string} eventName - The SSE event name (e.g. "message", "endpoint")
+ * @param {string} data - The event payload
+ */
+function sendSSEEvent(res, eventName, data) {
+    try {
+        // SSE format being followed is each event results in two lines:
+        //   event: <eventName>
+        //   data: <string data>
+        //   [blank line]
+        res.write(`event: ${eventName}\n`);
+        res.write(`data: ${data}\n\n`);
+    } catch (error) {
+        console.error(`[SSE] Error sending SSE event: ${error}`);
+        res.destroy(error);
+    }
+}
+
+server.listen(3000, "127.0.0.1", () => {
+    console.log("[SSE] Server listening on http://127.0.0.1:3000");
+});

--- a/Sources/SwiftMCP/Transport/SSETransport.swift
+++ b/Sources/SwiftMCP/Transport/SSETransport.swift
@@ -1,51 +1,63 @@
+import os // for logger
 import Foundation
 
-/// Transport implementation using Server-Sent Events (SSE)
-public actor SSETransport: MCPTransport {
-    public private(set) var state: TransportState = .disconnected
+public actor SSEClientTransport: MCPTransport {
     public let configuration: TransportConfiguration
+    /// The current state of the transport
+    public private(set) var state: TransportState = .disconnected
+    /// The endpoint we receive via the `endpoint` SSE event. Once known, we POST to it for sending messages.
+    public private(set) var postEndpoint: URL?
 
-    private let endpoint: URL
-    private let sessionId: String
-    private var eventSource: URLSessionStreamTask?
+    /// The base URL for the SSE connection (GET) request.
+    private let url: URL
+
+    /// Used for parsing SSE events
+    private var currentEvent: String?
+
+    /// Our internal `EventSource` task
+    private var task: Task<Void, Never>?
+
+    /// The continuation for the AsyncThrowingStream
     private var messagesContinuation: AsyncThrowingStream<Data, Error>.Continuation?
-    private let session: URLSession
-    private let decoder = JSONDecoder()
-    private let encoder = JSONEncoder()
+
+    /// A unique session identifier
+    private let sessionId: String
+
+    /// Extra request configuration (like headers) if needed
+    private let urlSession: URLSession
+
+    private let logger: Logger
 
     public init(
-        endpoint: URL,
+        url: URL,
         configuration: TransportConfiguration = .default,
-        session: URLSession = .shared
+        urlSession: URLSession = .shared
     ) {
-        self.endpoint = endpoint
+        self.url = url
         self.configuration = configuration
-        self.session = session
+        self.urlSession = urlSession
         self.sessionId = UUID().uuidString
+        self.logger = Logger(subsystem: "SwiftMCP", category: "SSEClientTransport")
+        self.currentEvent = nil
     }
 
+    /// Create a stream of messages from the SSE connection
+    /// This needs to be called before the downchannel is created
     public func messages() -> AsyncThrowingStream<Data, Error> {
         AsyncThrowingStream { continuation in
             self.messagesContinuation = continuation
-
-            // Auto-start if needed
             Task {
-                if self.state == .disconnected {
-                    do {
+                do {
+                    if self.state != .connected {
+                        // auto start the connection if not already connected
                         try await self.start()
-                        throw TransportError.connectionFailed(
-                            TransportError.invalidState(
-                                "Transport not connected"
-                            )
-                        )
-                    } catch {
-                        continuation.finish(throwing: error)
-                        return
                     }
-                }
 
-                // Setup event monitoring
-                await self.startEventMonitoring()
+                    // start the downchannel
+                    self.readSSEEvents(continuation: continuation)
+                } catch {
+                    continuation.finish(throwing: error)
+                }
             }
 
             continuation.onTermination = { [weak self] _ in
@@ -56,72 +68,154 @@ public actor SSETransport: MCPTransport {
         }
     }
 
+    /// Start the SSE connection
     public func start() async throws {
-        guard state == .disconnected else {
-            throw TransportError.invalidState("Transport already started")
+        guard state != .connected else {
+            throw TransportError.invalidState("Transport is already started")
         }
 
-        // TODO: implement
-
+        // the downchannel is only created when the `messages` iterator is active
+        // the state will move to "connected" once that completes
+        self.setState(.connecting)
     }
 
+    /// Stop the SSE connection
     public func stop() {
-        eventSource?.cancel()
-        eventSource = nil
+        if state == .disconnected {
+            return
+        }
+        self.setState(.disconnected)
+
+        // Cancel any ongoing Task
+        task?.cancel()
+        task = nil
+
+        // Finish the messages stream
         messagesContinuation?.finish()
-        state = .disconnected
+        messagesContinuation = nil
     }
 
+    /// Send data to the server via POST. We must have received the server-provided `postEndpoint` first.
     public func send(_ data: Data, timeout: TimeInterval? = nil) async throws {
         guard state == .connected else {
             throw TransportError.invalidState("Transport not connected")
         }
 
-        // Check message size
+        guard let endpoint = postEndpoint else {
+            throw TransportError.invalidState("Server endpoint not known yet")
+        }
+
         if data.count > configuration.maxMessageSize {
             throw TransportError.messageTooLarge(data.count)
         }
 
-        // Prepare request
-        var url = endpoint
-        url.append(queryItems: [URLQueryItem(name: "sessionId", value: sessionId)])
-
-        var request = URLRequest(url: url)
+        var request = URLRequest(url: endpoint)
         request.httpMethod = "POST"
         request.setValue("application/json", forHTTPHeaderField: "Content-Type")
         request.httpBody = data
 
-        // Set timeout if provided
-        if let timeout = timeout {
-            request.timeoutInterval = timeout
-        } else {
-            request.timeoutInterval = configuration.sendTimeout
+        // Timeout logic
+        let actualTimeout = timeout ?? configuration.sendTimeout
+        request.timeoutInterval = actualTimeout
+
+        let (_, response) = try await urlSession.data(for: request)
+        guard let httpResponse = response as? HTTPURLResponse,
+              (200...299).contains(httpResponse.statusCode)
+        else {
+            throw TransportError.invalidState("POST failed to \(endpoint)")
         }
+        logger.info("successfully sent data \(String(data: data, encoding: .utf8) ?? "<nil>")")
+    }
 
-        // Send request with timeout
-        let (_, response) = try await session.data(
-            for: request,
-            delegate: nil
-        )
+    /// Internal method to read SSE from the server
+    private func readSSEEvents(
+        continuation: AsyncThrowingStream<Data, Error>.Continuation
+    ) {
+        self.task = Task { [weak self] in
+            guard let self else { return }
 
-        // Verify response
-        guard let httpResponse = response as? HTTPURLResponse else {
-            throw TransportError.invalidState("Non-HTTP response received")
-        }
+            do {
+                let (asyncBytes, response) = try await self.urlSession.bytes(from: self.url)
 
-        guard (200...299).contains(httpResponse.statusCode) else {
-            throw TransportError.invalidState(httpResponse.statusCode.description)
+                guard let httpResponse = response as? HTTPURLResponse,
+                      (200...299).contains(httpResponse.statusCode)
+                else {
+                    logger.error("Non-200 status code from SSE: \(response)")
+                    throw TransportError.connectionFailed(
+                        TransportError.invalidState("Non-200 status code from SSE: \(response)")
+                    )
+                }
+
+                let contentType = httpResponse.value(forHTTPHeaderField: "Content-Type") ?? ""
+                guard contentType.contains("text/event-stream") else {
+                    throw TransportError.invalidState("Not an SSE response")
+                }
+
+                // we are connected now that we have a byte stream with no other response code errors
+                logger.info("Connected to downchannel")
+                await self.setState(.connected)
+
+                // SSE lines typically come in the form of:
+                // event: <something>
+                // data: <something>
+                // or
+                // data: <json>
+                // No whitespace rules are technically enforced, but we trim for whitespace on the endpoint event
+
+                for try await line in asyncBytes.lines {
+                    print("NOAH : \(line)")
+                    let startingChars = line.prefix(6).lowercased()
+
+                    if startingChars.starts(with: "event:") {
+                        let event = String(line.dropFirst("event:".count))
+                            .trimmingCharacters(in: .whitespaces)
+                        await self.setCurrentEvent(event)
+                        continue
+                    }
+
+                    if startingChars.starts(with: "data:") {
+                        let rawData = String(line.dropFirst("data:".count))
+                        logger.debug("Received SSE data: \(rawData)")
+                        if await self.currentEvent == "endpoint" {
+                            let trimmedEndpoint = rawData.trimmingCharacters(in: .whitespacesAndNewlines)
+                            if let newEndpoint = URL(string: trimmedEndpoint) {
+                                await self.setPostEndpoint(newEndpoint)
+                                continue
+                            }
+                        } else {
+                            let trimmed = rawData.trimmingCharacters(in: .whitespaces)
+                            if let data = trimmed.data(using: .utf8) {
+                                logger.debug("Yielding SSE data: \(data)")
+                                continuation.yield(data)
+                                continue
+                            }
+                        }
+                    }
+                    // unhandled event / message payload
+                    throw TransportError.invalidMessage("Unhandled line of byte stream in SSEClientTransport. Line must start 'data:' or 'event:' . Line was: \(line)")
+                }
+                logger.info("SSE downchannel closed")
+                continuation.finish()
+            } catch {
+                logger.error("Error reading SSE events: \(error)")
+                continuation.finish(throwing: error)
+            }
         }
     }
 
-    /// Monitor SSE events from the server
-    private func startEventMonitoring() async {
-        // TODO: implement
-
-        messagesContinuation?.finish()
+    private func setCurrentEvent(_ event: String) {
+        logger.debug("[setCurrentEvent] Setting current event to \(event)")
+        self.currentEvent = event
     }
 
-    private func setEventSource(_ task: URLSessionStreamTask) {
-        self.eventSource = task
+    private func setState(_ state: TransportState) {
+        logger.debug("[setState] Setting current transport state to \(state)")
+        self.state = state
     }
+
+    private func setPostEndpoint(_ endpoint: URL) {
+        logger.debug("[setPostEndpoint] setting postEndpoint URL \(endpoint)")
+        self.postEndpoint = endpoint
+    }
+
 }

--- a/Sources/SwiftMCP/Transport/TransportConfiguration.swift
+++ b/Sources/SwiftMCP/Transport/TransportConfiguration.swift
@@ -121,9 +121,6 @@ public enum TransportState {
     /// Transport is connected and ready
     case connected
 
-    /// Transport is temporarily paused
-    case suspended
-
     /// Transport has permanently failed
     case failed(Error)
 }
@@ -134,7 +131,6 @@ extension TransportState: CustomStringConvertible, CustomDebugStringConvertible 
         case .disconnected: return "disconnected"
         case .connecting: return "connecting"
         case .connected: return "connected"
-        case .suspended: return "suspended"
         case .failed(let error): return "failed: \(error)"
         }
     }
@@ -144,7 +140,6 @@ extension TransportState: CustomStringConvertible, CustomDebugStringConvertible 
         case .disconnected: return "Transport is disconnected"
         case .connecting: return "Transport is connecting"
         case .connected: return "Transport is connected"
-        case .suspended: return "Transport is suspended"
         case .failed(let error): return "Transport has failed: \(error)"
         }
     }
@@ -156,8 +151,7 @@ extension TransportState: Equatable {
         case (.disconnected, .disconnected),
             (.connecting, .connecting),
             (.connected, .connected),
-            (.failed, .failed),
-            (.suspended, .suspended):
+            (.failed, .failed):
             return true
         default:
             return false

--- a/Tests/SwiftMCPTests/SSETransportTests.swift
+++ b/Tests/SwiftMCPTests/SSETransportTests.swift
@@ -1,0 +1,277 @@
+//
+//  SSETransportTests.swift
+//  SwiftMCP
+//
+//  Created by Noah Lozevski on 1/14/25.
+//
+
+import Foundation
+import Testing
+@testable import SwiftMCP
+
+@Suite("SSEClientTransport Tests", .serialized)
+struct SSEClientTransportTests {
+
+    /// ../../../
+    private var repoRootPath: URL {
+        let thisFile = URL(fileURLWithPath: #filePath)
+        return thisFile
+            .deletingLastPathComponent()
+            .deletingLastPathComponent()
+            .deletingLastPathComponent()
+    }
+
+    /// <REPO>/JS/sse.js
+    private var sseScriptPath: String {
+        let scriptURL = repoRootPath.appendingPathComponent("JS/sse.js")
+        return scriptURL.path
+    }
+
+    /// Must match the setup from JS
+    private let sseServerEndpoint = URL(string: "http://127.0.0.1:3000/sse")!
+
+    private func spawnSSEServer() -> StdioTransport {
+        StdioTransport(
+            options: .init(
+                command: "node",
+                arguments: [sseScriptPath],
+                environment: ProcessInfo.processInfo.environment
+            )
+        )
+    }
+
+    @Test("Connects to dummy SSE server, receives endpoint event, sets postEndpoint")
+    func testConnectionAndEndpoint() async throws {
+        let server = spawnSSEServer()
+
+        let serverLogsTask = Task {
+            for try await line in await server.messages() {
+                print("Server Log:", String(data: line, encoding: .utf8) ?? "<nil>")
+            }
+        }
+
+        try await server.start()
+        // wait a sec
+        try await Task.sleep(for: .milliseconds(500))
+
+        let sseTransport = SSEClientTransport(
+            url: sseServerEndpoint,
+            configuration: .default
+        )
+
+        var receivedMessages = [Data]()
+        let messagesTask = Task {
+            for try await msg in await sseTransport.messages() {
+                receivedMessages.append(msg)
+            }
+        }
+
+        try await Task.sleep(for: .seconds(1))
+
+        // We expect the SSE server to send an "endpoint" event with data: <postURL>.
+        // SSEClientTransport should set `postEndpoint` from that event.
+        let postEndpoint = await sseTransport.postEndpoint
+        #expect(postEndpoint != nil)  // We should have discovered the endpoint
+        #expect(await sseTransport.state == .connected)
+
+        // 🧹💨💨
+        await sseTransport.stop()
+        await server.stop()
+        try await messagesTask.value
+        serverLogsTask.cancel()
+    }
+
+    @Test("Sends data to SSE server; receives no immediate errors")
+    func testDataTransfer() async throws {
+        let server = spawnSSEServer()
+        let serverLogsTask = Task {
+            for try await line in await server.messages() {
+                print("Server Log:", String(data: line, encoding: .utf8) ?? "<nil>")
+            }
+        }
+
+        try await server.start()
+        try await Task.sleep(for: .milliseconds(500))
+
+        let sseTransport = SSEClientTransport(url: sseServerEndpoint)
+
+        let messagesTask = Task {
+            for try await _ in await sseTransport.messages() { }
+        }
+
+        // Wait for the "endpoint" event to set postEndpoint
+        try await Task.sleep(for: .seconds(1))
+        let postURL = await sseTransport.postEndpoint
+        #expect(postURL != nil)
+
+        let testMessage = Data(#"{"hello":"world"}"#.utf8)
+        do {
+            try await sseTransport.send(testMessage)
+            // we dont care what was returned just that the fact that it succeeded
+        } catch {
+            Issue.record("Sending data threw an error: \(error)")
+        }
+
+        await sseTransport.stop()
+        await server.stop()
+        try await messagesTask.value
+        serverLogsTask.cancel()
+    }
+
+    @Test("Handles server close/disconnect gracefully")
+    func testServerDisconnection() async throws {
+        let server = spawnSSEServer()
+        try await server.start()
+        try await Task.sleep(for: .milliseconds(300))
+
+        let sseTransport = SSEClientTransport(url: sseServerEndpoint)
+        let messagesTask = Task {
+            for try await _ in await sseTransport.messages() { }
+        }
+
+        try await Task.sleep(for: .milliseconds(500))
+        #expect(await sseTransport.state == .connected)
+
+        // STOP 🛑
+        await server.stop()
+
+        // hold-up
+        try await Task.sleep(for: .seconds(1))
+
+        #expect(true, "No crash or exception means success.")
+
+        await sseTransport.stop()
+        try await messagesTask.value
+    }
+
+    @Test("Can reconnect after stopping SSEClientTransport")
+    func testReconnection() async throws {
+        let server = spawnSSEServer()
+        try await server.start()
+        try await Task.sleep(for: .milliseconds(300))
+
+        let sseTransport = SSEClientTransport(url: sseServerEndpoint)
+
+        let firstSessionTask = Task {
+            for try await _ in await sseTransport.messages() {}
+        }
+
+        try await Task.sleep(for: .milliseconds(500))
+        #expect(await sseTransport.state == .connected)
+
+        await sseTransport.stop()
+        #expect(await sseTransport.state == .disconnected)
+
+        let secondSessionTask = Task {
+            for try await _ in await sseTransport.messages() {}
+        }
+
+        try await Task.sleep(for: .milliseconds(500))
+        #expect(await sseTransport.state == .connected)
+
+        // Cleanup
+        await sseTransport.stop()
+        await server.stop()
+        try await firstSessionTask.value
+        try await secondSessionTask.value
+    }
+
+    @Test("Handles server changing the post endpoint mid-connection")
+    func testEndpointChangeEvent() async throws {
+        let server = spawnSSEServer()
+        try await server.start()
+        try await Task.sleep(for: .milliseconds(300))
+
+        let sseTransport = SSEClientTransport(url: sseServerEndpoint)
+        let messagesTask = Task {
+            for try await _ in await sseTransport.messages() {}
+        }
+
+        try await Task.sleep(for: .seconds(1))
+        let firstEndpoint = await sseTransport.postEndpoint
+        #expect(firstEndpoint != nil, "First endpoint is set")
+
+        do {
+            // trigger endpoint change
+            try await sseTransport.send(Data(#"client::changeEndpoint"#.utf8))
+        } catch { }
+
+        try await Task.sleep(for: .seconds(3))
+        let secondEndpoint = await sseTransport.postEndpoint
+        #expect(secondEndpoint != nil, "Second endpoint is set or remains unchanged")
+        #expect(firstEndpoint != secondEndpoint, "Endpoints are the same. they should have updated.")
+
+        // Cleanup
+        await sseTransport.stop()
+        await server.stop()
+        try await messagesTask.value
+    }
+
+    @Test("Handles error response from the server for data send")
+    func testDataSendError() async throws {
+        let server = spawnSSEServer()
+        try await server.start()
+        try await Task.sleep(for: .milliseconds(300))
+
+        let sseTransport = SSEClientTransport(url: sseServerEndpoint)
+        let messagesTask = Task {
+            for try await _ in await sseTransport.messages() {}
+        }
+
+        try await Task.sleep(for: .seconds(1))
+        let postURL = await sseTransport.postEndpoint
+        #expect(postURL != nil)
+
+        // trigger 5XX on post
+        let badData = Data(#"client::badMessage"#.utf8)
+        do {
+            try await sseTransport.send(badData)
+            Issue.record("Expected an error but got none")
+        } catch {
+            #expect(true)
+        }
+
+        await sseTransport.stop()
+        await server.stop()
+        try await messagesTask.value
+    }
+
+    @Test("Handles forced server close/disconnect gracefully")
+    func testServerDisconnect() async throws {
+        let server = spawnSSEServer()
+        let serverLogsTask = Task {
+            for try await line in await server.messages() {
+                print("Server Log:", String(data: line, encoding: .utf8) ?? "<nil>")
+            }
+        }
+
+        try await server.start()
+        try await Task.sleep(for: .milliseconds(300))
+
+        let sseTransport = SSEClientTransport(url: sseServerEndpoint)
+        let messagesTask = Task {
+            for try await line in await sseTransport.messages() {
+                print("Server Log:", String(data: line, encoding: .utf8) ?? "<nil>")
+            }
+        }
+
+        try await Task.sleep(for: .seconds(1))
+        let postURL = await sseTransport.postEndpoint
+        #expect(postURL != nil)
+
+        let disconnectMsg = Data(#"client::disconnect"#.utf8)
+        try? await sseTransport.send(disconnectMsg)
+
+        do {
+            try await messagesTask.value
+            #expect(true, "server disconnect should not throw")
+            #expect(await sseTransport.state == .disconnected)
+        } catch {
+            Issue.record("server side initiated disconnect should not throw, it should be handled the same as client initiated disconnect")
+        }
+
+        await sseTransport.stop()
+        await server.stop()
+        serverLogsTask.cancel()
+    }
+}


### PR DESCRIPTION
This pull request finalizes the **SSEClientTransport** class, enabling the MCP client to connect via **(SSE)**. Key improvements include:

1. **Downchannel Connection**  
   - On client startup, an asynchronous SSE GET request (the “downchannel”) is established.  
   - An `event: endpoint` message from the server informs the client of the correct POST URL.  
   - The client sets `postEndpoint` only when the server sends this `endpoint` event.  

2. **Data Serialization & POST**  
   - The client can now send data back to the SSE server over HTTP POST once `postEndpoint` is known.  
   - If no endpoint is received, an error is raised when attempting to send.  

3. **Error Handling & Graceful Termination**  
   - If the SSE stream fails (network error, unexpected status code, etc.), the client closes its message stream with an error.  
   - If the server or client terminates normally, the transport finishes gracefully without throwing.  

4. **Test Coverage**  
   - Introduces a **Node.js-based SSE server** (`sse.js`) for local integration tests.  
   - The Swift test suite spawns this server (requires `node` in the PATH) and exercises typical scenarios:
     - Basic connection and receiving the `endpoint` event  
     - Sending messages (POST) to the server  
     - Handling errors and server-initiated disconnects  
     - Changing endpoints mid-connection  
   - Verifies that the client transitions to `.connected`, updates `postEndpoint` as expected, and handles edge cases.  


Other notes
- I removed the `suspended` transport state. i couldnt think of when this would be needed and i thought it was useless
- Need to hook this up and test this with a real server